### PR TITLE
Prevent stale verification callbacks with operation tokens

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -46,7 +46,7 @@ android {
     }
 
     dependencies {
-        implementation("io.okhi.android:okhi:1.0.12")
+        implementation("io.okhi.android:okhi:1.0.13")
         testImplementation("org.jetbrains.kotlin:kotlin-test")
         testImplementation("org.mockito:mockito-core:5.0.0")
     }

--- a/android/src/main/kotlin/io/okhi/flutter/okhi_flutter/OkhiFlutterPlugin.kt
+++ b/android/src/main/kotlin/io/okhi/flutter/okhi_flutter/OkhiFlutterPlugin.kt
@@ -50,6 +50,7 @@ class OkhiFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
     private lateinit var cachedLocation: Location
     private var eventSink: EventChannel.EventSink? = null
     private var isFetchingLocation = false
+    private var activeOperationToken: Int = 0
 
     override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
         context = flutterPluginBinding.applicationContext
@@ -163,16 +164,19 @@ class OkhiFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
         call: MethodCall,
         result: Result
     ) {
+        val token = activeOperationToken
         OkHi.createAddress(
             activity,
             collect,
             object : OkHiAddressVerificationCallback() {
                 override fun onSuccess(response: OkHiSuccessResponse) {
+                    if (activeOperationToken != token) return
                     val eventObject = getSuccessEventObject("createAddress", response)
                     sendEvent(eventObject)
                 }
 
                 override fun onClose() {
+                    if (activeOperationToken != token) return
                     val eventObject= JSONObject()
                     eventObject.put("methodCall","createAddress")
                     eventObject.put("type","closed")
@@ -180,6 +184,7 @@ class OkhiFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
                 }
 
                 override fun onError(e: OkHiException) {
+                    if (activeOperationToken != token) return
                     val eventObject= JSONObject()
                     eventObject.put("methodCall","createAddress")
                     eventObject.put("type","error")
@@ -188,22 +193,26 @@ class OkhiFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
                     sendEvent(eventObject)
                 }
             })
+        result.success(null)
     }
 
     private fun handleStartDigitalAndPhysicalVerification(
         call: MethodCall,
         result: Result
     ) {
+        val token = activeOperationToken
         OkHi.startDigitalAndPhysicalAddressVerification(
             activity,
             collect,
             object : OkHiAddressVerificationCallback() {
                 override fun onSuccess(response: OkHiSuccessResponse) {
+                    if (activeOperationToken != token) return
                     val eventObject = getSuccessEventObject("startDigitalAndPhysicalAddressVerification", response)
                     sendEvent(eventObject)
                 }
 
                 override fun onClose() {
+                    if (activeOperationToken != token) return
                     val eventObject= JSONObject()
                     eventObject.put("methodCall","startDigitalAndPhysicalAddressVerification")
                     eventObject.put("type","closed")
@@ -211,6 +220,7 @@ class OkhiFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
                 }
 
                 override fun onError(e: OkHiException) {
+                    if (activeOperationToken != token) return
                     val eventObject= JSONObject()
                     eventObject.put("methodCall","startDigitalAndPhysicalAddressVerification")
                     eventObject.put("type","error")
@@ -219,22 +229,26 @@ class OkhiFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
                     sendEvent(eventObject)
                 }
             })
+        result.success(null)
     }
 
     private fun handleStartPhysicalVerification(
         call: MethodCall,
         result: Result
     ) {
+        val token = activeOperationToken
         OkHi.startPhysicalAddressVerification(
             activity,
             collect,
             object : OkHiAddressVerificationCallback() {
                 override fun onSuccess(response: OkHiSuccessResponse) {
+                    if (activeOperationToken != token) return
                     val eventObject = getSuccessEventObject("startPhysicalAddressVerification", response)
                     sendEvent(eventObject)
                 }
 
                 override fun onClose() {
+                    if (activeOperationToken != token) return
                     val eventObject= JSONObject()
                     eventObject.put("methodCall","startPhysicalAddressVerification")
                     eventObject.put("type","closed")
@@ -242,6 +256,7 @@ class OkhiFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
                 }
 
                 override fun onError(e: OkHiException) {
+                    if (activeOperationToken != token) return
                     val eventObject= JSONObject()
                     eventObject.put("methodCall","startPhysicalAddressVerification")
                     eventObject.put("type","error")
@@ -250,22 +265,26 @@ class OkhiFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
                     sendEvent(eventObject)
                 }
             })
+        result.success(null)
     }
 
     private fun handleStartDigitalVerification(
         call: MethodCall,
         result: Result
     ) {
+        val token = activeOperationToken
         OkHi.startDigitalAddressVerification(
             activity,
             collect,
             object : OkHiAddressVerificationCallback() {
                 override fun onSuccess(response: OkHiSuccessResponse) {
+                    if (activeOperationToken != token) return
                     val eventObject = getSuccessEventObject("startDigitalAddressVerification", response)
                     sendEvent(eventObject)
                 }
 
                 override fun onClose() {
+                    if (activeOperationToken != token) return
                     val eventObject= JSONObject()
                     eventObject.put("methodCall","startDigitalAddressVerification")
                     eventObject.put("type","closed")
@@ -273,6 +292,7 @@ class OkhiFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
                 }
 
                 override fun onError(e: OkHiException) {
+                    if (activeOperationToken != token) return
                     val eventObject= JSONObject()
                     eventObject.put("methodCall","startDigitalAddressVerification")
                     eventObject.put("type","error")
@@ -282,23 +302,27 @@ class OkhiFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
                 }
             }
         )
+        result.success(null)
     }
 
     private fun handleStartSavedVerification(
         locationId: String,
         result: Result
     ) {
+        val token = activeOperationToken
         val collectInstance = OkCollect(collect.style, collect.config, OkHiLocation(locationId))
         OkHi.startAddressVerification(
             activity,
             collectInstance,
             object : OkHiAddressVerificationCallback() {
                 override fun onSuccess(response: OkHiSuccessResponse) {
+                    if (activeOperationToken != token) return
                     val eventObject = getSuccessEventObject("startSavedAddressVerification", response)
                     sendEvent(eventObject)
                 }
 
                 override fun onClose() {
+                    if (activeOperationToken != token) return
                     val eventObject= JSONObject()
                     eventObject.put("methodCall","startSavedAddressVerification")
                     eventObject.put("type","closed")
@@ -306,6 +330,7 @@ class OkhiFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
                 }
 
                 override fun onError(e: OkHiException) {
+                    if (activeOperationToken != token) return
                     val eventObject= JSONObject()
                     eventObject.put("methodCall","startSavedAddressVerification")
                     eventObject.put("type","error")
@@ -316,6 +341,7 @@ class OkhiFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
 
             }
         )
+        result.success(null)
     }
 
     private fun getSuccessEventObject(methodCall: String, response: OkHiSuccessResponse): JSONObject {
@@ -508,6 +534,8 @@ class OkhiFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
                     okhiUserId = userId,
                     token = token
                 )
+                activeOperationToken++
+
                 OkHi.login(context, auth, okHiUser) { locationIds ->
                     // todo: handle login
                 }

--- a/android/src/main/kotlin/io/okhi/flutter/okhi_flutter/OkhiFlutterPlugin.kt
+++ b/android/src/main/kotlin/io/okhi/flutter/okhi_flutter/OkhiFlutterPlugin.kt
@@ -502,12 +502,12 @@ class OkhiFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
                 result.error("unauthorized", "invalid initialization credentials provided", null)
             } else {
 
-                var style = OkCollectStyle("#263238", "OkHi", "https://cdn.okhi.co/icon.png")
+                var style = OkCollectStyle("#005D67", "OkHi", "https://cdn.okhi.co/icon.png")
                 var config = OkCollectConfig(true, true, false, true)
 
                 if(locationManagerConfiguration != null) {
                     style = OkCollectStyle(
-                        (locationManagerConfiguration["color"] as? String) ?: "#263238",
+                        (locationManagerConfiguration["color"] as? String) ?: "#005D67",
                         (locationManagerConfiguration["appName"] as? String) ?: "OkHi",
                         (locationManagerConfiguration["logoUrl"] as? String) ?: "https://cdn.okhi.co/icon.png"
                     )

--- a/android/src/main/kotlin/io/okhi/flutter/okhi_flutter/OkhiFlutterPlugin.kt
+++ b/android/src/main/kotlin/io/okhi/flutter/okhi_flutter/OkhiFlutterPlugin.kt
@@ -496,7 +496,7 @@ class OkhiFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
             val branchId: String? = call.argument("branchId")
             val clientKey: String? = call.argument("clientKey")
             val mode: String? = call.argument("environment")
-            val locationManagerConfiguration: Map<String, String>? = call.argument("locationManagerConfiguration")
+            val locationManagerConfiguration: Map<String, Any>? = call.argument("locationManagerConfiguration")
 
             if (branchId == null || clientKey == null || mode == null) {
                 result.error("unauthorized", "invalid initialization credentials provided", null)
@@ -506,12 +506,17 @@ class OkhiFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
                 var config = OkCollectConfig(true, true, false, true)
 
                 if(locationManagerConfiguration != null) {
-                    style = OkCollectStyle(locationManagerConfiguration["color"].toString(), locationManagerConfiguration["appName"].toString(), locationManagerConfiguration["logoUrl"].toString())
+                    style = OkCollectStyle(
+                        (locationManagerConfiguration["color"] as? String) ?: "#263238",
+                        (locationManagerConfiguration["appName"] as? String) ?: "OkHi",
+                        (locationManagerConfiguration["logoUrl"] as? String) ?: "https://cdn.okhi.co/icon.png"
+                    )
                     config = OkCollectConfig(
-                        locationManagerConfiguration["withStreetView"] == "true",
-                        locationManagerConfiguration["withHomeAddressType"] == "true",
-                        locationManagerConfiguration["withWorkAddressType"] == "true",
-                        locationManagerConfiguration["withAppBar"] == "true")
+                        (locationManagerConfiguration["withStreetView"] as? Boolean) ?: true,
+                        (locationManagerConfiguration["withHomeAddressType"] as? Boolean) ?: true,
+                        (locationManagerConfiguration["withWorkAddressType"] as? Boolean) ?: false,
+                        (locationManagerConfiguration["withAppBar"] as? Boolean) ?: true
+                    )
                 }
 
                 collect = OkCollect(style, config)

--- a/example/lib/main_workspace.dart
+++ b/example/lib/main_workspace.dart
@@ -60,9 +60,9 @@ class _OkHiHomePageState extends State<OkHiHomePage> {
   final _lastNameCtrl = TextEditingController();
   final _appUserIdCtrl = TextEditingController();
   final _emailCtrl = TextEditingController();
-  final _branchIdCtrl = TextEditingController(text: "bGlA1qWeiB");
+  final _branchIdCtrl = TextEditingController(text: "B0lKOrJaUN");
   final _clientKeyCtrl = TextEditingController(
-    text: "c728dcef-bc6b-4e0f-b6f2-b29df973366d",
+    text: "73957af9-faef-4c9f-ad27-e0abe969f76a",
   );
 
   @override

--- a/ios/Classes/OkhiFlutterPlugin.swift
+++ b/ios/Classes/OkhiFlutterPlugin.swift
@@ -328,7 +328,8 @@ public class OkhiFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHandler {
                 )
 
             theme = OkHiTheme()
-                .with(primaryColor: locationManagerConfiguration["color"] as? String ?? "")
+                .with(appBarColor: locationManagerConfiguration["color"] as? String ?? "#005D67")
+                .with(primaryColor: locationManagerConfiguration["color"] as? String ?? "#005D67")
                 .with(logoUrl: locationManagerConfiguration["logoUrl"] as? String ?? "")
 
             do {

--- a/ios/Classes/OkhiFlutterPlugin.swift
+++ b/ios/Classes/OkhiFlutterPlugin.swift
@@ -18,6 +18,7 @@ public class OkhiFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHandler {
 
     private var verificationSuccessResult: ((Any) -> Void)?
     private var verificationErrorResult: ((FlutterError) -> Void)?
+    private var activeOperationToken: Int = 0
 
     private func topViewController() -> UIViewController? {
         let keyWindow = UIApplication.shared.windows.first { $0.isKeyWindow }
@@ -331,6 +332,7 @@ public class OkhiFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHandler {
                 .with(logoUrl: locationManagerConfiguration["logoUrl"] as? String ?? "")
 
             do {
+                self.activeOperationToken += 1
                 OK.shared.login(auth: auth, user: user){ list in
                     print("OkHi Initialized successfully on iOS platform: \(list)")
                     result(true)
@@ -381,7 +383,9 @@ public class OkhiFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHandler {
             return
         }
 
-        OK.shared.startAddressVerification(vc: viewController, theme: theme, config: appConfigInstance, location: okhiLocation) { response, error in
+        let token = activeOperationToken
+        OK.shared.startAddressVerification(vc: viewController, theme: theme, config: appConfigInstance, location: okhiLocation) { [weak self] response, error in
+            guard let self = self, self.activeOperationToken == token else { return }
             if let validResponse = response {
                 self.emit(self.getSuccessEvent(methodCall: method, response: validResponse))
             } else if let error = error {
@@ -395,6 +399,7 @@ public class OkhiFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHandler {
                 )
             }
         }
+        result(nil)
     }
 
     private func handleStartPhysicalVerification(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
@@ -410,7 +415,9 @@ public class OkhiFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHandler {
             return
         }
 
-        OK.shared.startPhysicalAddressVerification(vc: viewController, theme: theme, config: appConfig) { response, error in
+        let token = activeOperationToken
+        OK.shared.startPhysicalAddressVerification(vc: viewController, theme: theme, config: appConfig) { [weak self] response, error in
+            guard let self = self, self.activeOperationToken == token else { return }
             if let validResponse = response {
                 self.emit(self.getSuccessEvent(methodCall: "startPhysicalAddressVerification", response: validResponse))
             } else if let error = error {
@@ -424,6 +431,7 @@ public class OkhiFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHandler {
                 )
             }
         }
+        result(nil)
     }
 
     private func handleStartDigitalAndPhysicalVerification(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
@@ -438,7 +446,9 @@ public class OkhiFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHandler {
             )
             return
         }
-        OK.shared.startDigitalAndPhysicalAddressVerification(vc: viewController, theme: theme, config: appConfig) { response, error in
+        let token = activeOperationToken
+        OK.shared.startDigitalAndPhysicalAddressVerification(vc: viewController, theme: theme, config: appConfig) { [weak self] response, error in
+            guard let self = self, self.activeOperationToken == token else { return }
             if let validResponse = response {
                 self.emit(self.getSuccessEvent(methodCall: "startDigitalAndPhysicalAddressVerification", response: validResponse))
             } else if let error = error {
@@ -452,6 +462,7 @@ public class OkhiFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHandler {
                 )
             }
         }
+        result(nil)
     }
 
     private func handleCreateAddress(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
@@ -466,7 +477,9 @@ public class OkhiFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHandler {
             )
             return
         }
-        OK.shared.createAddress(vc: viewController, theme: theme, config: appConfig) { response, error in
+        let token = activeOperationToken
+        OK.shared.createAddress(vc: viewController, theme: theme, config: appConfig) { [weak self] response, error in
+            guard let self = self, self.activeOperationToken == token else { return }
             if let validResponse = response {
                 self.emit(self.getSuccessEvent(methodCall: "createAddress", response: validResponse))
             } else if let error = error {
@@ -480,6 +493,7 @@ public class OkhiFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHandler {
                 )
             }
         }
+        result(nil)
     }
 
     private func getSuccessEvent(methodCall: String, response: OkHiSuccessResponse) -> [String : Any?] {

--- a/ios/Classes/OkhiFlutterPlugin.swift
+++ b/ios/Classes/OkhiFlutterPlugin.swift
@@ -323,8 +323,8 @@ public class OkhiFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHandler {
 
             appConfig = OkHiConfig()
                 .withAddressTypes(
-                    work: locationManagerConfiguration["withWorkAddressType"] as? Int == 1,
-                    home: locationManagerConfiguration["withHomeAddressType"] as? Int == 1
+                    work: locationManagerConfiguration["withWorkAddressType"] as? Bool == true,
+                    home: locationManagerConfiguration["withHomeAddressType"] as? Bool == true
                 )
 
             theme = OkHiTheme()

--- a/ios/okhi_flutter.podspec
+++ b/ios/okhi_flutter.podspec
@@ -20,5 +20,5 @@ The official OkHi Flutter plugin for collecting and verifying user addresses on 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
   s.swift_version = '5.0'
-  s.dependency 'OkHi', '1.10.14'
+  s.dependency 'OkHi', '1.10.16'
 end

--- a/lib/okhi_flutter.dart
+++ b/lib/okhi_flutter.dart
@@ -201,6 +201,11 @@ class OkHi {
           : null,
     };
 
+    await streamSubscription?.cancel();
+    streamSubscription = null;
+    onVerificationSuccess = null;
+    onVerificationError = null;
+
     streamSubscription = okhiVerificationStream.listen((dynamic event) {
       if (event.resultType == "success") {
         if (event.user != null && event.location != null) {

--- a/lib/okhi_flutter.dart
+++ b/lib/okhi_flutter.dart
@@ -189,6 +189,7 @@ class OkHi {
       "locationManagerConfiguration": locationManagerConfiguration != null
           ? {
               "color": locationManagerConfiguration.color,
+              "appName": locationManagerConfiguration.appName,
               "logoUrl": locationManagerConfiguration.logoUrl,
               "withAppBar": locationManagerConfiguration.withAppBar,
               "withCreateMode": locationManagerConfiguration.withCreateMode,


### PR DESCRIPTION
- Implement an `activeOperationToken` mechanism in iOS and Android to ignore results from outdated verification sessions
- Ensure native verification methods return immediately to the Flutter layer after initiation
- Update `lib/okhi_flutter.dart` to cancel and reset existing stream subscriptions and callbacks before re-initializing
- Use weak references in iOS callbacks to prevent potential memory leaks and ensure token validation logic is safe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved address verification flows so stale results from earlier attempts no longer interfere with the current session.
  * Made login and verification setup more reliable by resetting previous listeners before starting a new one.
  * Updated configuration handling to better support app and address-type settings during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->