### PR TITLE
Prepare release v2.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 2.0.5
+
+- Fix: Prevent stale verification callbacks from previous sessions by tracking active operation tokens on Android and iOS
+- Fix: Cancel and reset existing stream subscriptions and callbacks before re-initializing verification
+- Fix: Correct address type casting on iOS (`withWorkAddressType`/`withHomeAddressType` now read as `Bool` instead of `Int`)
+- Fix: Handle `locationManagerConfiguration` casting and defaults for `OkCollectStyle`/`OkCollectConfig` on Android
+- Added: `appName` support to `OkHiLocationManagerConfiguration`
+- Added: `appBarColor` support to iOS theme configuration
+- Updated: default branding color to `#005D67` across Android and iOS
+- Upgrade: Bumped native SDKs - Android `okhi` to 1.0.13, iOS `OkHi` to 1.10.16
+
 ## 2.0.4
 
 - Fix Null entries for address location response.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: okhi_flutter
 description: The OkHi Flutter library will enable you to start collecting and verifying your user's addresses.
-version: 2.0.4
+version: 2.0.5
 homepage: https://docs.okhi.co
 repository: https://github.com/OkHi/okhi-flutter
 


### PR DESCRIPTION
- Bump version to 2.0.5 in pubspec.yaml and update CHANGELOG.md
- Prevent stale verification callbacks by tracking active operation tokens on Android and iOS
- Reset stream subscriptions and callbacks before re-initializing verification
- Fix address type casting on iOS (`Bool` vs `Int`) and `locationManagerConfiguration` casting on Android
- Add `appName` support to `OkHiLocationManagerConfiguration` and `appBarColor` to iOS theme
- Update default branding color to `#005D67`
- Upgrade native SDKs: Android to 1.0.13 and iOS to 1.10.16