### PR TITLE
Release 2.0.6: Add closeAddressCollection and upgrade native SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.6
+
+- Added: `OkHi.closeAddressCollection()` method to programmatically close the address collection UI from the Flutter layer, implemented across Android and iOS
+- Upgrade: Bumped native SDKs - Android `okhi` to 1.0.16, iOS `OkHi` to 1.10.18
+
 ## 2.0.5
 
 - Fix: Prevent stale verification callbacks from previous sessions by tracking active operation tokens on Android and iOS

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: okhi_flutter
 description: The OkHi Flutter library will enable you to start collecting and verifying your user's addresses.
-version: 2.0.5
+version: 2.0.6
 homepage: https://docs.okhi.co
 repository: https://github.com/OkHi/okhi-flutter
 


### PR DESCRIPTION
- Added `OkHi.closeAddressCollection()` method to programmatically close the address collection UI from the Flutter layer, implemented for both Android and iOS.
- Upgraded native SDK dependencies:
  - Android `okhi` to 1.0.16.
  - iOS `OkHi` to 1.10.18.
- Bumped package version to 2.0.6 in `pubspec.yaml`.